### PR TITLE
Remove Python < 2.3 Code

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+trilinos (12.18.1-deepin2) unstable; urgency=medium
+
+  * Remove Python < 2.3 Code.
+    Code like True = 1 is now causing SyntaxError on Python 3
+
+ -- Tianyu Chen <sweetyfish@deepin.org>  Fri, 07 Jul 2023 13:46:12 +0800
+
 trilinos (12.18.1-deepin1) unstable; urgency=medium
 
   * Rebuild

--- a/debian/patches/remove-python-2.3.patch
+++ b/debian/patches/remove-python-2.3.patch
@@ -1,0 +1,19 @@
+Description: Remove Python < 2.3 Code
+ Code like True = 1 is now causing SyntaxError on Python 3.
+Author: Tianyu Chen <sweetyfish@deepin.org>
+Origin: vendor
+Forwarded: not-needed
+Last-Update: 2023-07-07
+---
+--- a/commonTools/test/utilities/compareTestOutput
++++ b/commonTools/test/utilities/compareTestOutput
+@@ -13,9 +13,6 @@
+ import getopt
+ 
+ version = sys.version_info[0] + sys.version_info[1]/10.0
+-if version < 2.3:
+-    True = 1
+-    False = 0
+ 
+ 
+ class CompareRule:

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,3 +2,4 @@ multiarch.patch
 kokkos-header-time.patch
 kokkos-make-4.3.patch
 skip-pliris_vector_random.patch
+remove-python-2.3.patch


### PR DESCRIPTION
**!! trilinos 可能会构建较长时间，按照 obs history，大概需要构建四到五个小时以上。**

Code like `True = 1` is now causing SyntaxError on Python 3.

Fix build error on obs.

![image](https://github.com/deepin-community/trilinos/assets/124018391/1f04e8de-b1c6-40df-bee7-e4937431f970)

```
Running: "/usr/bin/python3" "/usr/src/packages/BUILD/commonTools/test/utilities/compareTestOutput" "evaluateCriteria" "baseline1.txt" "ValidateParameters_compareTestOutput.out"

--------------------------------------------------------------------------------

  File "/usr/src/packages/BUILD/commonTools/test/utilities/compareTestOutput", line 17
    True = 1
    ^^^^
SyntaxError: cannot assign to True

--------------------------------------------------------------------------------

TEST_1: Return code = 1
TEST_1: Pass criteria = Match REGEX {Test passed.} [FAILED]
TEST_1: Result = FAILED
TEST_1: FAIL FAST, SKIPPING REST OF TEST CASES!

================================================================================

OVERALL FINAL RESULT: TEST FAILED (ML_ValidateParameters_compareTestOutput)
```